### PR TITLE
Add mypy to improve type hints

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10.12, 3.11, 3.12]
+        python-version: [3.12]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: MyPy
 
 on:
   pull_request:
@@ -27,5 +27,5 @@ jobs:
       - name: Install dependencies with uv
         run: uv sync --all-extras --dev
 
-      - name: Run Pytest
-        run: uv run pytest
+      - name: Run MyPy
+        run: uv run mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hash-forge"
-version = "1.2.0"
+version = "1.2.1"
 description = "Hash Forge is a lightweight Python library designed to simplify the process of hashing and verifying data using a variety of secure hashing algorithms."
 readme = "README.md"
 authors = [{ name = "Zozi", email = "zozi.fer96@gmail.com" }]
@@ -14,7 +14,7 @@ keywords = [
     "scrypt",
     "blake2",
     "Whirlpool",
-    "RIPEMD-160"
+    "RIPEMD-160",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -35,7 +35,14 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.uv]
-dev-dependencies = ["pytest>=8.3.3"]
+dev-dependencies = ["mypy>=1.13.0", "pytest>=8.3.3"]
+
+[tool.mypy]
+files = "src/hash_forge"
+strict = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+warn_return_any = true
 
 [project.optional-dependencies]
 bcrypt = ["bcrypt==4.2.0"]

--- a/src/hash_forge/hashers/argon2_hasher.py
+++ b/src/hash_forge/hashers/argon2_hasher.py
@@ -1,12 +1,13 @@
 from functools import partial
 from contextlib import suppress
+from typing import ClassVar, cast, Any
 
 from hash_forge.protocols import PHasher
 
 
 class Argon2Hasher(PHasher):
-    algorithm: str = 'argon2'
-    library_module: str = 'argon2'
+    algorithm: ClassVar[str] = 'argon2'
+    library_module: ClassVar[str] = 'argon2'
 
     def __init__(
         self,
@@ -47,7 +48,7 @@ class Argon2Hasher(PHasher):
             str: The formatted hash string containing the algorithm, time cost, memory cost, parallelism, salt, and hashed value.
         """
 
-        return self.algorithm + self.ph.hash(_string)
+        return self.algorithm + cast(str, self.ph.hash(_string))
 
     def verify(self, _string: str, _hashed_string: str, /) -> bool:
         """
@@ -62,7 +63,7 @@ class Argon2Hasher(PHasher):
         """
         with suppress(self.argon2.exceptions.VerifyMismatchError, self.argon2.exceptions.InvalidHash, Exception):
             _, _hashed_string = _hashed_string.split('$', 1)
-            return self.ph.verify('$' + _hashed_string, _string)
+            return cast(bool, self.ph.verify('$' + _hashed_string, _string))
         return False
 
     def needs_rehash(self, _hashed_string: str, /) -> bool:
@@ -77,10 +78,10 @@ class Argon2Hasher(PHasher):
         """
         with suppress(self.argon2.exceptions.InvalidHash, Exception):
             _, _hashed_string = _hashed_string.split('$', 1)
-            return self.ph.check_needs_rehash('$' + _hashed_string)
+            return cast(bool, self.ph.check_needs_rehash('$' + _hashed_string))
         return False
 
-    def _get_hasher(self):
+    def _get_hasher(self) -> Any:
         """
         Creates and returns a configured instance of argon2.PasswordHasher.
 

--- a/src/hash_forge/hashers/bcrypt_hasher.py
+++ b/src/hash_forge/hashers/bcrypt_hasher.py
@@ -2,15 +2,15 @@ import binascii
 import hashlib
 
 from contextlib import suppress
-from typing import Callable
+from typing import Any, Callable, ClassVar, Optional, cast
 
 from hash_forge.protocols import PHasher
 
 
 class BCryptSha256Hasher(PHasher):
-    algorithm: str = 'bcrypt_sha256'
-    library_module: str = 'bcrypt'
-    digest: Callable | None = hashlib.sha256
+    algorithm: ClassVar[str] = 'bcrypt_sha256'
+    library_module: ClassVar[str] = 'bcrypt'
+    digest: Callable[[bytes], Any] | None = cast(Callable[[bytes], Any], hashlib.sha256)
 
     def __init__(self, rounds: int = 12) -> None:
         """
@@ -58,7 +58,7 @@ class BCryptSha256Hasher(PHasher):
             encoded_string: bytes = _string.encode()
             if self.digest is not None:
                 encoded_string = self._get_hexdigest(_string, self.digest)
-            return self.bcrypt.checkpw(encoded_string, ('$' + hashed_val).encode('ascii'))
+            return cast(bool, self.bcrypt.checkpw(encoded_string, ('$' + hashed_val).encode('ascii')))
         except (ValueError, TypeError, IndexError):
             return False
 
@@ -86,7 +86,7 @@ class BCryptSha256Hasher(PHasher):
         return False
 
     @staticmethod
-    def _get_hexdigest(_string: str, digest: Callable) -> bytes:
+    def _get_hexdigest(_string: str, digest: Callable[[bytes], Any]) -> bytes:
         """
         Generate a hexadecimal digest for a given string using the specified digest function.
 

--- a/src/hash_forge/hashers/blake2_hasher.py
+++ b/src/hash_forge/hashers/blake2_hasher.py
@@ -2,11 +2,13 @@ import binascii
 import hashlib
 import hmac
 
+from typing import ClassVar
+
 from hash_forge.protocols import PHasher
 
 
 class Blake2Hasher(PHasher):
-    algorithm: str = 'blake2b'
+    algorithm: ClassVar[str] = 'blake2b'
 
     def __init__(self, key: str, digest_size: int = 64) -> None:
         """

--- a/src/hash_forge/hashers/pbkdf2_hasher.py
+++ b/src/hash_forge/hashers/pbkdf2_hasher.py
@@ -3,15 +3,14 @@ import os
 import binascii
 import hmac
 
-from contextlib import suppress
-from typing import Callable
+from typing import Any, Callable, ClassVar
 
 from hash_forge.protocols import PHasher
 
 
 class PBKDF2Sha256Hasher(PHasher):
-    algorithm: str = 'pbkdf2_sha256'
-    digest: Callable = hashlib.sha256
+    algorithm: ClassVar[str] = 'pbkdf2_sha256'
+    digest: ClassVar[Callable[..., Any]] = hashlib.sha256
 
     def __init__(self, iterations: int = 100_000, salt_length: int = 16) -> None:
         self.iterations = iterations

--- a/src/hash_forge/hashers/ripemd160_hasher.py
+++ b/src/hash_forge/hashers/ripemd160_hasher.py
@@ -1,11 +1,12 @@
 import hmac
+from typing import ClassVar
 
 from hash_forge.protocols import PHasher
 
 
 class Ripemd160Hasher(PHasher):
-    algorithm: str = 'RIPEMD-160'
-    library_module: str = 'Crypto.Hash.RIPEMD160'
+    algorithm: ClassVar[str] = 'RIPEMD-160'
+    library_module: ClassVar[str] = 'Crypto.Hash.RIPEMD160'
 
     def __init__(self) -> None:
         """

--- a/src/hash_forge/hashers/scrypt_hasher.py
+++ b/src/hash_forge/hashers/scrypt_hasher.py
@@ -4,13 +4,13 @@ import secrets
 import hmac
 
 from functools import lru_cache
-
+from typing import ClassVar
 
 from hash_forge.protocols import PHasher
 
 
 class ScryptHasher(PHasher):
-    algorithm: str = 'scrypt'
+    algorithm: ClassVar[str] = 'scrypt'
 
     def __init__(
         self,
@@ -51,7 +51,7 @@ class ScryptHasher(PHasher):
         Returns:
             str: The hashed string in the format 'algorithm$work_factor$salt$block_size$parallelism$hashed_value'.
         """
-        salt: str = self.generate_salt()
+        salt = self.generate_salt()
         hashed = hashlib.scrypt(
             _string.encode(),
             salt=salt.encode(),
@@ -61,8 +61,15 @@ class ScryptHasher(PHasher):
             maxmem=self.maxmem,
             dklen=self.dklen,
         )
-        hashed = base64.b64encode(hashed).decode('ascii').strip()
-        return '%s$%s$%s$%s$%s$%s' % (self.algorithm, self.work_factor, salt, self.block_size, self.parallelism, hashed)
+        hashed_string = base64.b64encode(hashed).decode('ascii').strip()
+        return '%s$%s$%s$%s$%s$%s' % (
+            self.algorithm,
+            self.work_factor,
+            salt,
+            self.block_size,
+            self.parallelism,
+            hashed_string,
+        )
 
     def verify(self, _string: str, _hashed_string: str) -> bool:
         """

--- a/src/hash_forge/hashers/whirlpool_hasher.py
+++ b/src/hash_forge/hashers/whirlpool_hasher.py
@@ -1,11 +1,12 @@
 import hmac
+from typing import ClassVar
 
 from hash_forge.protocols import PHasher
 
 
 class WhirlpoolHasher(PHasher):
-    algorithm: str = 'whirlpool'
-    library_module: str = 'Crypto.Hash.SHA512'
+    algorithm: ClassVar[str] = 'whirlpool'
+    library_module: ClassVar[str] = 'Crypto.Hash.SHA512'
 
     def __init__(self) -> None:
         """

--- a/src/hash_forge/utils.py
+++ b/src/hash_forge/utils.py
@@ -3,7 +3,7 @@ import secrets
 from hash_forge.constants import RANDOM_STRING_CHARS
 
 
-def get_random_string(length, allowed_chars=RANDOM_STRING_CHARS) -> str:
+def get_random_string(length: int, allowed_chars: str = RANDOM_STRING_CHARS) -> str:
     """
     Return a securely generated random string.
 

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "hash-forge"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -159,6 +159,7 @@ crypto = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "pytest" },
 ]
 
@@ -170,7 +171,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.3" }]
+dev = [
+    { name = "mypy", specifier = ">=1.13.0" },
+    { name = "pytest", specifier = ">=8.3.3" },
+]
 
 [[package]]
 name = "iniconfig"
@@ -179,6 +183,49 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+]
+
+[[package]]
+name = "mypy"
+version = "1.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/21/7e9e523537991d145ab8a0a2fd98548d67646dc2aaaf6091c31ad883e7c1/mypy-1.13.0.tar.gz", hash = "sha256:0291a61b6fbf3e6673e3405cfcc0e7650bebc7939659fdca2702958038bd835e", size = 3152532 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/8c/206de95a27722b5b5a8c85ba3100467bd86299d92a4f71c6b9aa448bfa2f/mypy-1.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6607e0f1dd1fb7f0aca14d936d13fd19eba5e17e1cd2a14f808fa5f8f6d8f60a", size = 11020731 },
+    { url = "https://files.pythonhosted.org/packages/ab/bb/b31695a29eea76b1569fd28b4ab141a1adc9842edde080d1e8e1776862c7/mypy-1.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8a21be69bd26fa81b1f80a61ee7ab05b076c674d9b18fb56239d72e21d9f4c80", size = 10184276 },
+    { url = "https://files.pythonhosted.org/packages/a5/2d/4a23849729bb27934a0e079c9c1aad912167d875c7b070382a408d459651/mypy-1.13.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b2353a44d2179846a096e25691d54d59904559f4232519d420d64da6828a3a7", size = 12587706 },
+    { url = "https://files.pythonhosted.org/packages/5c/c3/d318e38ada50255e22e23353a469c791379825240e71b0ad03e76ca07ae6/mypy-1.13.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0730d1c6a2739d4511dc4253f8274cdd140c55c32dfb0a4cf8b7a43f40abfa6f", size = 13105586 },
+    { url = "https://files.pythonhosted.org/packages/4a/25/3918bc64952370c3dbdbd8c82c363804678127815febd2925b7273d9482c/mypy-1.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:c5fc54dbb712ff5e5a0fca797e6e0aa25726c7e72c6a5850cfd2adbc1eb0a372", size = 9632318 },
+    { url = "https://files.pythonhosted.org/packages/d0/19/de0822609e5b93d02579075248c7aa6ceaddcea92f00bf4ea8e4c22e3598/mypy-1.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:581665e6f3a8a9078f28d5502f4c334c0c8d802ef55ea0e7276a6e409bc0d82d", size = 10939027 },
+    { url = "https://files.pythonhosted.org/packages/c8/71/6950fcc6ca84179137e4cbf7cf41e6b68b4a339a1f5d3e954f8c34e02d66/mypy-1.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3ddb5b9bf82e05cc9a627e84707b528e5c7caaa1c55c69e175abb15a761cec2d", size = 10108699 },
+    { url = "https://files.pythonhosted.org/packages/26/50/29d3e7dd166e74dc13d46050b23f7d6d7533acf48f5217663a3719db024e/mypy-1.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:20c7ee0bc0d5a9595c46f38beb04201f2620065a93755704e141fcac9f59db2b", size = 12506263 },
+    { url = "https://files.pythonhosted.org/packages/3f/1d/676e76f07f7d5ddcd4227af3938a9c9640f293b7d8a44dd4ff41d4db25c1/mypy-1.13.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3790ded76f0b34bc9c8ba4def8f919dd6a46db0f5a6610fb994fe8efdd447f73", size = 12984688 },
+    { url = "https://files.pythonhosted.org/packages/9c/03/5a85a30ae5407b1d28fab51bd3e2103e52ad0918d1e68f02a7778669a307/mypy-1.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:51f869f4b6b538229c1d1bcc1dd7d119817206e2bc54e8e374b3dfa202defcca", size = 9626811 },
+    { url = "https://files.pythonhosted.org/packages/fb/31/c526a7bd2e5c710ae47717c7a5f53f616db6d9097caf48ad650581e81748/mypy-1.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5c7051a3461ae84dfb5dd15eff5094640c61c5f22257c8b766794e6dd85e72d5", size = 11077900 },
+    { url = "https://files.pythonhosted.org/packages/83/67/b7419c6b503679d10bd26fc67529bc6a1f7a5f220bbb9f292dc10d33352f/mypy-1.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:39bb21c69a5d6342f4ce526e4584bc5c197fd20a60d14a8624d8743fffb9472e", size = 10074818 },
+    { url = "https://files.pythonhosted.org/packages/ba/07/37d67048786ae84e6612575e173d713c9a05d0ae495dde1e68d972207d98/mypy-1.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:164f28cb9d6367439031f4c81e84d3ccaa1e19232d9d05d37cb0bd880d3f93c2", size = 12589275 },
+    { url = "https://files.pythonhosted.org/packages/1f/17/b1018c6bb3e9f1ce3956722b3bf91bff86c1cefccca71cec05eae49d6d41/mypy-1.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a4c1bfcdbce96ff5d96fc9b08e3831acb30dc44ab02671eca5953eadad07d6d0", size = 13037783 },
+    { url = "https://files.pythonhosted.org/packages/cb/32/cd540755579e54a88099aee0287086d996f5a24281a673f78a0e14dba150/mypy-1.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0affb3a79a256b4183ba09811e3577c5163ed06685e4d4b46429a271ba174d2", size = 9726197 },
+    { url = "https://files.pythonhosted.org/packages/11/bb/ab4cfdc562cad80418f077d8be9b4491ee4fb257440da951b85cbb0a639e/mypy-1.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a7b44178c9760ce1a43f544e595d35ed61ac2c3de306599fa59b38a6048e1aa7", size = 11069721 },
+    { url = "https://files.pythonhosted.org/packages/59/3b/a393b1607cb749ea2c621def5ba8c58308ff05e30d9dbdc7c15028bca111/mypy-1.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5d5092efb8516d08440e36626f0153b5006d4088c1d663d88bf79625af3d1d62", size = 10063996 },
+    { url = "https://files.pythonhosted.org/packages/d1/1f/6b76be289a5a521bb1caedc1f08e76ff17ab59061007f201a8a18cc514d1/mypy-1.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2904956dac40ced10931ac967ae63c5089bd498542194b436eb097a9f77bc8", size = 12584043 },
+    { url = "https://files.pythonhosted.org/packages/a6/83/5a85c9a5976c6f96e3a5a7591aa28b4a6ca3a07e9e5ba0cec090c8b596d6/mypy-1.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:7bfd8836970d33c2105562650656b6846149374dc8ed77d98424b40b09340ba7", size = 13036996 },
+    { url = "https://files.pythonhosted.org/packages/b4/59/c39a6f752f1f893fccbcf1bdd2aca67c79c842402b5283563d006a67cf76/mypy-1.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:9f73dba9ec77acb86457a8fc04b5239822df0c14a082564737833d2963677dbc", size = 9737709 },
+    { url = "https://files.pythonhosted.org/packages/3b/86/72ce7f57431d87a7ff17d442f521146a6585019eb8f4f31b7c02801f78ad/mypy-1.13.0-py3-none-any.whl", hash = "sha256:9c250883f9fd81d212e0952c92dbfcc96fc237f4b7c92f56ac81fd48460b3e5a", size = 2647043 },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695 },
 ]
 
 [[package]]
@@ -256,4 +303,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/b9/de2a5c0144d7d75a57ff355c0c24054f965b2dc3036456ae03a51ea6264b/tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed", size = 16096 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/db/ce8eda256fa131af12e0a76d481711abe4681b6923c27efb9a255c9e4594/tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38", size = 13237 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
 ]


### PR DESCRIPTION
This pull request includes several updates to improve type safety, add MyPy checks, and update the project configuration. The most important changes include setting up a MyPy workflow, updating type annotations across various files, and adding MyPy configuration to the project.

### Workflow and Configuration Updates:
* Added a new GitHub Actions workflow for MyPy to check type annotations on pull requests targeting the `develop` and `main` branches. (`.github/workflows/mypy.yml`)
* Updated the `unittest` workflow to include the `main` branch. (`.github/workflows/unittest.yml`)
* Updated `pyproject.toml` to bump the version to `1.2.1`, add MyPy as a development dependency, and configure MyPy settings. (`pyproject.toml`) [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L38-R45)

### Type Annotations:
* Added `ClassVar` type annotations to class variables in multiple hasher files to improve type safety. (`src/hash_forge/hashers/argon2_hasher.py`, `src/hash_forge/hashers/bcrypt_hasher.py`, `src/hash_forge/hashers/blake2_hasher.py`, `src/hash_forge/hashers/pbkdf2_hasher.py`, `src/hash_forge/hashers/ripemd160_hasher.py`, `src/hash_forge/hashers/scrypt_hasher.py`, `src/hash_forge/hashers/whirlpool_hasher.py`) [[1]](diffhunk://#diff-fe4539feab08bfbd1b43e9f8b12038f2f7e1690f38b419dfee5cc3037325e908R3-R10) [[2]](diffhunk://#diff-3dc1b78c6173fe2f2b5be99bcafbac690e736d5cbcd5f7f8c12aefc19fe25280L5-R13) [[3]](diffhunk://#diff-24332747a3516a3febe83c310b1485113ba3a6eef30ecf3b141ca84ad0116747R5-R11) [[4]](diffhunk://#diff-c477f6dcf4f1b21f4d1b95d47deeaa5966e4ac3a4f7a9af07e884db2a3e9b333L6-R13) [[5]](diffhunk://#diff-36f92a571166200c4d90f46c5bf24012177b324ece760585da1ec64cf4176564R2-R9) [[6]](diffhunk://#diff-5d742f1225ffdd721578c78c32049d5113271feb4ec152200aee7f349cefb1fdL7-R13) [[7]](diffhunk://#diff-f31cb0f85a28bea5ef4a7938af3654d183e19a6286379851b46a3670e1df2f64R2-R9)
* Updated method signatures to include type annotations for parameters and return types. (`src/hash_forge/hashers/argon2_hasher.py`, `src/hash_forge/hashers/bcrypt_hasher.py`, `src/hash_forge/hashers/scrypt_hasher.py`, `src/hash_forge/utils.py`) [[1]](diffhunk://#diff-fe4539feab08bfbd1b43e9f8b12038f2f7e1690f38b419dfee5cc3037325e908L50-R51) [[2]](diffhunk://#diff-3dc1b78c6173fe2f2b5be99bcafbac690e736d5cbcd5f7f8c12aefc19fe25280L61-R61) [[3]](diffhunk://#diff-5d742f1225ffdd721578c78c32049d5113271feb4ec152200aee7f349cefb1fdL54-R54) [[4]](diffhunk://#diff-7e7d201aab8f06b99c915d3f376f5f3cdd0fb032af37d60ae4af5b8851a73e40L6-R6)

### Code Improvements:
* Refactored hashing methods to use `cast` for type assertions, ensuring type safety. (`src/hash_forge/hashers/argon2_hasher.py`, `src/hash_forge/hashers/bcrypt_hasher.py`) [[1]](diffhunk://#diff-fe4539feab08bfbd1b43e9f8b12038f2f7e1690f38b419dfee5cc3037325e908L50-R51) [[2]](diffhunk://#diff-3dc1b78c6173fe2f2b5be99bcafbac690e736d5cbcd5f7f8c12aefc19fe25280L61-R61)
* Simplified the `hash` method in `ScryptHasher` for better readability. (`src/hash_forge/hashers/scrypt_hasher.py`)